### PR TITLE
Avoid rule overrides 

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,10 +149,17 @@ Here's the docs of every configurable option from Node's documentation:
 - `dest` destination path to copy to.
 - `dereference` dereference symlinks.
 - `errorOnExist` when `force` is `false` and the destination exists, throw an error.
-- `filter` function to filter copied files / directories. Return `true` to copy the item, `false` to ignore it.
 - `force` overwrite existing file or directory. The copy operation will ignore errors if you set this to false and the destination exists. Use the `errorOnExist` option to change this behavior.
 - `preserveTimestamps` when `true` timestamps from `src` will be preserved.
 - `recursive` copy directories recursively.
+- `filter` function to filter copied files / directories. Return `true` to copy the item, `false` to ignore it.  
+
+```
+filter?(source: string, destination: string): boolean;
+  @need `fs.cpSync` — node.js v16.7.0 
+  @param src — source path to copy.  
+  @param dest — destination path to copy to.  
+```
 
 ### How does the filter function work?
 

--- a/index.js
+++ b/index.js
@@ -44,6 +44,7 @@ module.exports = (options = {}) => ({
 
     let filterUser = options.filter || false;
     let filterRun = filterUser ? filterSynthesis.bind(null, filterUser) : filter;
+
     build.onEnd(() => fs.cpSync(src, dest, {
       dereference: options.dereference || true,
       errorOnExist: options.errorOnExist || false,

--- a/index.js
+++ b/index.js
@@ -45,12 +45,12 @@ module.exports = (options = {}) => ({
     let filterUser = options.filter || false;
     let filterRun = filterUser ? filterSynthesis.bind(null, filterUser) : filter;
     build.onEnd(() => fs.cpSync(src, dest, {
-      dereference: true,
-      errorOnExist: false,
+      dereference: options.dereference || true,
+      errorOnExist: options.errorOnExist || false,
       filter: filterRun,
-      force: true,
-      preserveTimestamps: true,
-      recursive: true,
+      force: options.force || true,
+      preserveTimestamps: options.preserveTimestamps || true,
+      recursive: options.recursive || true,
     }))
   },
 })

--- a/index.js
+++ b/index.js
@@ -32,19 +32,25 @@ function filter(src, dest) {
   return getFileDigest(src) !== getFileDigest(dest)
 }
 
+function filterSynthesis(userFilter, src, dest) {
+  return userFilter(src, dest) && filter(src, dest);
+}
+
 module.exports = (options = {}) => ({
   name: 'copy-static-files',
   setup(build) {
     let src = options.src || './static'
     let dest = options.dest || '../public'
 
+    let filterUser = options.filter || false;
+    let filterRun = filterUser ? filterSynthesis.bind(null, filterUser) : filter;
     build.onEnd(() => fs.cpSync(src, dest, {
-      dereference: options.dereference || true,
-      errorOnExist: options.errorOnExist || false,
-      filter: options.filter || filter,
-      force: options.force || true,
-      preserveTimestamps: options.preserveTimestamps || true,
-      recursive: options.recursive || true,
+      dereference: true,
+      errorOnExist: false,
+      filter: filterRun,
+      force: true,
+      preserveTimestamps: true,
+      recursive: true,
     }))
   },
 })


### PR DESCRIPTION
# sugget 1
Sugget to providing more documentation to user code `filter` rules .

I am search for "why `fs.CpSync()` is not a function", until i Hover to `fs.CpSync()`, it ***need node.js v16.7.0***.

# sugget 2

When I wrote `My_filter()` , the **static files also copy**, because of `filter: options.filter || filter` , `My_filter()` directly covered your rules .